### PR TITLE
display: do not hardcode the xdg_wm_base version

### DIFF
--- a/display.c
+++ b/display.c
@@ -115,7 +115,7 @@ static void registry_global(void *private, struct wl_registry *registry,
 	else if (!strcmp(interface, xdg_wm_base_interface.name))
 		display->xdg_shell = wl_registry_bind(registry, id,
 						      &xdg_wm_base_interface,
-						      3);
+						      version);
 }
 
 static void registry_global_remove(void *private, struct wl_registry *registry,


### PR DESCRIPTION
The version is hardcoded to 3 here which breaks on some compositors. I'm running SwayWM 1.9 and I'm getting following error: wl_registry@2: error 0: invalid version for global xdg_wm_base (12): have 2, wanted 3